### PR TITLE
Remove Sui Alpha References

### DIFF
--- a/contents/content.json
+++ b/contents/content.json
@@ -5628,7 +5628,7 @@
     },
     {
       "name": "sui",
-      "title": "Sui [Alpha]",
+      "title": "Sui",
       "author": "nakji_team",
       "verified": true,
       "active": true,
@@ -5673,7 +5673,7 @@
       "versions": [
         {
           "number": "0.0.0",
-          "changelog": "Alpha testing"
+          "changelog": "Beta release"
         }
       ]
     },


### PR DESCRIPTION
This PR makes the entry for Sui on Connector Explorer consistent with other connecters.

Sui connector had references to alpha testing in its title and under the versions tab. This is being removed now that Sui is complete. 